### PR TITLE
CI: Same build commands for test_pip_pkg and cpython_interop

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -115,7 +115,7 @@ jobs:
 
   build_to_wasm:
     name: Build LPython to WASM
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -130,6 +130,7 @@ jobs:
 
       - uses: hendrikmuhs/ccache-action@main
         with:
+          variant: sccache
           key: ${{ github.job }}-${{ matrix.os }}
 
       - name : Remove existing node
@@ -149,11 +150,8 @@ jobs:
             cd emsdk
 
             ./emsdk install 3.1.35
-
             ./emsdk activate 3.1.35
-
             ./emsdk install node-14.18.2-64bit
-
             ./emsdk activate node-14.18.2-64bit
 
       - name: Show Emscripten and Node Info
@@ -173,7 +171,20 @@ jobs:
             set -ex
             source $HOME/ext/emsdk/emsdk_env.sh # Activate Emscripten
             ./build0.sh
-            ./build_to_wasm.sh
+            emcmake cmake . -GNinja \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DCMAKE_CXX_FLAGS_DEBUG="-Wall -Wextra -fexceptions" \
+              -DWITH_LLVM=no \
+              -DLPYTHON_BUILD_TO_WASM=yes \
+              -DLFORTRAN_BUILD_ALL=yes \
+              -DWITH_STACKTRACE=no \
+              -DWITH_RUNTIME_STACKTRACE=no \
+              -DCMAKE_PREFIX_PATH="$CONDA_PREFIX" \
+              -DCMAKE_INSTALL_PREFIX=`pwd`/inst \
+              -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+
+            cmake --build . -j16 --target install
 
       - name: Test built lpython.wasm
         shell: bash -l {0}
@@ -196,26 +207,30 @@ jobs:
         with:
           environment-file: ci/environment.yml
           create-args: >-
+            python=3.10
             bison=3.4
 
       - uses: hendrikmuhs/ccache-action@main
         with:
+          variant: sccache
           key: ${{ github.job }}-${{ matrix.os }}
-
-      - name: Setup Platform (Linux)
-        shell: bash -l {0}
-        run: |
-            echo "LFORTRAN_CMAKE_GENERATOR=Unix Makefiles" >> $GITHUB_ENV
-            echo "WIN=0" >> $GITHUB_ENV
-            echo "MACOS=0" >> $GITHUB_ENV
-            echo "ENABLE_RUNTIME_STACKTRACE=yes" >> $GITHUB_ENV
-            echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
-            echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
 
       - name: Build Linux
         shell: bash -l {0}
         run: |
-            xonsh ci/build.xsh
+            ./build0.sh
+            cmake . -GNinja \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DWITH_LLVM=yes \
+              -DLFORTRAN_BUILD_ALL=yes \
+              -DWITH_STACKTRACE=no \
+              -DWITH_RUNTIME_STACKTRACE=yes \
+              -DCMAKE_PREFIX_PATH="$CONDA_PREFIX" \
+              -DCMAKE_INSTALL_PREFIX=`pwd`/inst \
+              -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+
+            cmake --build . -j16 --target install
 
       - name: PIP show version
         shell: bash -l {0}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -193,7 +193,7 @@ jobs:
             source $HOME/ext/emsdk/emsdk_env.sh # Activate Emscripten
             which node
             node -v
-            node src/lpython/tests/test_lpython.js
+            node --experimental-wasm-bigint src/lpython/tests/test_lpython.js
 
   test_pip_pkgs:
     name: Test PIP Installable Packages

--- a/src/lpython/tests/CMakeLists.txt
+++ b/src/lpython/tests/CMakeLists.txt
@@ -32,6 +32,14 @@ endif()
 # Add one main test suite for LPython, composed of many individual cpp files:
 add_executable(test_lpython ${SRC})
 target_link_libraries(test_lpython lpython_lib p::doctest)
+if (HAVE_BUILD_TO_WASM)
+    set(WASM_COMPILE_FLAGS "-g0 -fexceptions")
+    set(WASM_LINK_FLAGS
+      "-Oz -g0 -fexceptions -Wall -Wextra -s ASSERTIONS -s ALLOW_MEMORY_GROWTH=1 -s WASM_BIGINT"
+    )
+    set_target_properties(test_lpython PROPERTIES COMPILE_FLAGS ${WASM_COMPILE_FLAGS})
+    set_target_properties(test_lpython PROPERTIES LINK_FLAGS ${WASM_LINK_FLAGS})
+endif()
 add_test(test_lpython ${PROJECT_BINARY_DIR}/test_lpython)
 
 set_target_properties(test_lpython PROPERTIES


### PR DESCRIPTION
It seems the CI job for cpython_interop completes much earlier compared to test_pip_pkg. Therefore using the same build commands for cpython_interop in test_pip_pkg.